### PR TITLE
Switch to standard build, test, deploy workflow names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,31 @@ defaults: &defaults
 version: 2
 
 jobs:
-  test:
+  build:
     <<: *defaults
-    environment:
-      GOSS_FILES_STRATEGY: cp
-
     steps:
       - checkout
-
       - setup_remote_docker
-
       - run:
           name: Build Docker image
           command: |
             docker build -t tiddlywiki .
             docker save tiddlywiki | gzip -c > tiddlywiki.tar.gz
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - tiddlywiki.tar.gz
+            - tests
+
+  test:
+    <<: *defaults
+    environment:
+      GOSS_FILES_STRATEGY: cp
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run: docker load --input tiddlywiki.tar.gz
       - run:
           name: Install dependencies
           command: |
@@ -34,23 +44,16 @@ jobs:
             cd tests/
             dgoss run tiddlywiki --server
 
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - tiddlywiki.tar.gz
-
-  tag:
+  deploy:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /tmp/workspace
-
       - setup_remote_docker
-
+      - run: docker load --input tiddlywiki.tar.gz
       - run:
           name: Tag Docker image
           command: |
-            docker load --input tiddlywiki.tar.gz
             PATCH_VERSION=$(docker run -it --rm tiddlywiki --version | sed 's/[^0-9.]*//g')
             MAJOR_VERSION=$(echo "$PATCH_VERSION" | sed 's/\..*//')
             echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
@@ -64,8 +67,13 @@ workflows:
   version: 2
   build:
     jobs:
-      - test
-      - tag:
+      - build
+
+      - test:
+          requires:
+            - build
+
+      - deploy:
           requires:
             - test
           filters:


### PR DESCRIPTION
This more logical naming scheme also provides a better structure for parallel testing of different kinds and is what you see in almost all of the CircleCI workflow documentation.