### PR TITLE
Add a Makefile to handle common project commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,13 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache --no-progress make
+      - run:
           name: Build Docker image
           command: |
-            docker build -t tiddlywiki .
+            make build
             docker save tiddlywiki | gzip -c > tiddlywiki.tar.gz
       - persist_to_workspace:
           root: /tmp/workspace
@@ -36,13 +40,12 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk add --no-cache --no-progress bash curl
+            apk add --no-cache --no-progress bash curl make
             curl -fsSL https://goss.rocks/install | sh
       - run:
           name: Test Docker image
           command: |
-            cd tests/
-            dgoss run tiddlywiki --server
+            make test
 
   deploy:
     <<: *defaults
@@ -54,14 +57,8 @@ jobs:
       - run:
           name: Tag Docker image
           command: |
-            PATCH_VERSION=$(docker run -it --rm tiddlywiki --version | sed 's/[^0-9.]*//g')
-            MAJOR_VERSION=$(echo "$PATCH_VERSION" | sed 's/\..*//')
             echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-            docker tag tiddlywiki "elasticdog/tiddlywiki:latest"
-            docker tag tiddlywiki "elasticdog/tiddlywiki:${PATCH_VERSION}"
-            docker tag tiddlywiki "elasticdog/tiddlywiki:${MAJOR_VERSION}"
-            docker image ls elasticdog/tiddlywiki
-            docker push elasticdog/tiddlywiki
+            make deploy
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,13 @@ jobs:
           root: /tmp/workspace
           paths:
             - tiddlywiki.tar.gz
-            - tests
 
   test:
     <<: *defaults
     environment:
       GOSS_FILES_STRATEGY: cp
     steps:
+      - checkout
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,7 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[Makefile]
+indent_size = unset
+indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,8 @@ exists in a subdirectory.
 To build the Docker image and test it, run the following commands:
 
     $ cd tiddlywiki-docker/
-    $ docker build -t tiddlywiki .
-    $ cd tests/
-    $ dgoss run tiddlywiki --server
+    $ make build
+    $ make test
 
 > For version bumps, don't forget to adjust the list of supported tags at the
 > top of the _[README][]_.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+DOCKER_HUB_REPOSITORY ?= elasticdog
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build:
+	docker build -t tiddlywiki .
+
+.PHONY: test
+test:
+	cd tests/ && dgoss run tiddlywiki --server
+
+.PHONY: tag
+tag: PATCH_VERSION := $(shell docker run -it --rm tiddlywiki --version | sed 's/[^0-9.]*//g')
+tag: MAJOR_VERSION := $(shell echo "${PATCH_VERSION}" | sed 's/\..*//')
+tag:
+	docker tag tiddlywiki "${DOCKER_HUB_REPOSITORY}/tiddlywiki:latest"
+	docker tag tiddlywiki "${DOCKER_HUB_REPOSITORY}/tiddlywiki:${PATCH_VERSION}"
+	docker tag tiddlywiki "${DOCKER_HUB_REPOSITORY}/tiddlywiki:${MAJOR_VERSION}"
+	docker image ls "${DOCKER_HUB_REPOSITORY}/tiddlywiki"
+
+.PHONY: deploy
+deploy: tag
+	docker push "${DOCKER_HUB_REPOSITORY}/tiddlywiki"
+
+.PHONY: clean
+clean:
+	docker rmi tiddlywiki

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,29 +2,3 @@ TiddlyWiki Docker tests
 =======================
 
 See <https://github.com/aelsabbahy/goss/tree/master/extras/dgoss>
-
-Demo Session
-------------
-
-    $ dgoss run elasticdog/tiddlywiki --server
-    INFO: Starting docker container
-    INFO: Container ID: 947be594
-    INFO: Found goss_wait.yaml, waiting for it to pass before running tests
-    INFO: Sleeping for 0.2
-    INFO: Container health
-    PID                 USER                TIME                COMMAND
-    30909               root                0:00                /sbin/tini -- tiddlywiki --server                                                                                    
-    30937               root                0:00                node /usr/local/bin/tiddlywiki --server                                                                              
-    INFO: Running Tests
-    Process: node: running: matches expectation: [true]
-    Process: tini: running: matches expectation: [true]
-    File: /tiddlywiki: exists: matches expectation: [true]
-    File: /tiddlywiki: filetype: matches expectation: ["directory"]
-    Package: tini: installed: matches expectation: [true]
-    Command: tiddlywiki --version: exit-status: matches expectation: [0]
-    Command: tiddlywiki --version: stdout: matches expectation: [5.1.17]
-    
-    
-    Total Duration: 0.475s
-    Count: 7, Failed: 0, Skipped: 0
-    INFO: Deleting container


### PR DESCRIPTION
This allows us to separate out the commands that are useful for development and/or manual management of images from the commands that are specific to running within a CI environment.

I'm not sure what the best conventions are regarding the naming for tags used when developing locally, but I'm sticking with a bare `tiddlywiki` with no repository name. That allows the actual `DOCKER_HUB_REPOSITORY` value to be abstracted out into a single variable (that's set by default to `elasticdog`), which is only really used for the deploy step which pushes it to the Docker Hub registry.