### PR TITLE
Utilize a .dockerignore file to minimize build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/*
+Dockerfile


### PR DESCRIPTION
We don't need anything beyond the _Dockerfile_ itself, so no need to send all of the extra data from the repository to the Docker daemon when building. This should also slightly lower the image size, and will keep us from accidentally committing things without explicitly allowing them through the recursive "ignore everything" pattern.

From a local test, this was the before:

    Sending build context to Docker daemon  538.1kB

...and this was the after:

    Sending build context to Docker daemon  3.072kB

See:
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#understand-build-context
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#exclude-with-dockerignore