### PR TITLE
Generate detailed test results when the tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             GOSS_OPTS: --format junit
           command: |
             mkdir -p test-results/junit
-            make --silent test | sed -n '/<?xml/,$p' > test-results/junit/results.xml
+            make --silent test | sed -n '/<?xml/,$p' > test-results/junit/results.xml || exit 0
           when: on_fail
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,18 @@ jobs:
           name: Test Docker image
           command: |
             make test
+      - run:
+          name: Generate detailed test results
+          environment:
+            GOSS_OPTS: --format junit
+          command: |
+            mkdir -p test-results/junit
+            make test > test-results/junit/results.xml
+          when: on_fail
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,9 @@ jobs:
             make test
       - run:
           name: Generate detailed test results
-          environment:
-            GOSS_OPTS: --format junit
           command: |
             mkdir -p test-results/junit
-            make --silent test | sed -n '/<?xml/,$p' > test-results/junit/results.xml || exit 0
+            env GOSS_OPTS='--format junit' make --silent test | sed -n '/<?xml/,$p' > test-results/junit/results.xml || exit 0
           when: on_fail
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             GOSS_OPTS: --format junit
           command: |
             mkdir -p test-results/junit
-            make test > test-results/junit/results.xml
+            make --silent test | sed -n '/<?xml/,$p' > test-results/junit/results.xml
           when: on_fail
       - store_test_results:
           path: test-results


### PR DESCRIPTION
These JUnit reports can automatically be parsed and displayed by CircleCI as part of the [test summary section of a build](https://circleci.com/gh/elasticdog/tiddlywiki-docker/98#tests/containers/0).

That said, I temporarily changed the name of the file directory test to "broken" in order to kick the tires, and it's not working 100% as expected. There seems to be a bug with either what `goss` is generating, or how CircleCI is parsing the reports...with the deliberate test failure, the test summary says:

> Your job ran **7** tests in junit with **0 failures**
> **Slowest test:** goss Command tiddlywiki --version exit-status (took 0.57 seconds).

Despite the _results.xml_ showing the failed job as expected:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="goss" errors="0" tests="7" failures="1" skipped="1" time="0.567" timestamp="2018-07-23T22:58:05Z">
<testcase name="File /broken exists" time="0.000">
<system-err>File: /broken: exists: doesn&#39;t match, expect: [true] found: [false]</system-err>
<failure>File: /broken: exists: doesn&#39;t match, expect: [true] found: [false]</failure>
</testcase>
<testcase name="File /broken filetype" time="0.000">
<skipped/><system-out>File: /broken: filetype: skipped</system-out>
</testcase>
<testcase name="Process node running" time="0.000">
<system-out>Process: node: running: matches expectation: [true]</system-out>
</testcase>
<testcase name="Process tini running" time="0.000">
<system-out>Process: tini: running: matches expectation: [true]</system-out>
</testcase>
<testcase name="Package tini installed" time="0.205">
<system-out>Package: tini: installed: matches expectation: [true]</system-out>
</testcase>
<testcase name="Command tiddlywiki --version exit-status" time="0.566">
<system-out>Command: tiddlywiki --version: exit-status: matches expectation: [0]</system-out>
</testcase>
<testcase name="Command tiddlywiki --version stdout" time="0.000">
<system-out>Command: tiddlywiki --version: stdout: all expectations found: [5.1.17]</system-out>
</testcase>
</testsuite>
```

I'll investigate the broken upstream behavior outside of this PR, since the actual plumbing appears to be fine.