### PR TITLE
Fix typo in dockerignore exclusion rule

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 **/*
-**/Dockerfile
+!Dockerfile


### PR DESCRIPTION
I had this wrong before and I'm still trying to figure out why the Docker Hub automated builds aren't working as expected. When I made this file originally, I meant to say ignore all files except for the _Dockerfile_. Oddly, things do build fine locally and in CI, and these changes seem to be affecting the build context size...but I suspect Docker Hub's build system is a bit more picky.