### PR TITLE
Try once more to not ignore the symlink source Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
-**/*
-!Dockerfile
+tests/*
+contrib/*
+Makefile
+LICENSE
+*.txt
+*.md


### PR DESCRIPTION
If this doesn't work, I'm not sure what else to try. The file is actually being parsed by Docker Hub and shown in build details (and has been this entire time), but when building, it's having trouble finding it.

```
Building in Docker Cloud's infrastructure...
Cloning into '.'...

KernelVersion: 4.4.0-1060-aws
Components: [{u'Version': u'18.03.1-ee-1-tp5', u'Name': u'Engine', u'Details': {u'KernelVersion': u'4.4.0-1060-aws', u'Os': u'linux', u'BuildTime': u'2018-06-23T07:58:56.000000000+00:00', u'ApiVersion': u'1.37', u'MinAPIVersion': u'1.12', u'GitCommit': u'1b30665', u'Arch': u'amd64', u'Experimental': u'false', u'GoVersion': u'go1.10.2'}}]
Arch: amd64
BuildTime: 2018-06-23T07:58:56.000000000+00:00
ApiVersion: 1.37
Platform: {u'Name': u''}
Version: 18.03.1-ee-1-tp5
MinAPIVersion: 1.12
GitCommit: 1b30665
Os: linux
GoVersion: go1.10.2
Starting build of index.docker.io/elasticdog/tiddlywiki:sync-documentation...
Unexpected error
Encountered error: 500 Server Error: Internal Server Error ("Cannot locate specified Dockerfile: Dockerfile")
Traceback (most recent call last):
  File "/stage/builder/runner.py", line 290, in _run self.build()
  File "/stage/builder/runner.py", line 214, in build self._build()
  File "/stage/builder/runner.py", line 202, in _build cache_repo)
  File "/stage/builder/build.py", line 43, in build_image for line in stream:
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 305, in _stream_helper yield self._result(response, json=decode)
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 220, in _result self._raise_for_status(response)
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 216, in _raise_for_status raise create_api_error_from_http_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/docker/errors.py", line 30, in create_api_error_from_http_exception raise cls(e, response=response, explanation=explanation)
APIError: 500 Server Error: Internal Server Error ("Cannot locate specified Dockerfile: Dockerfile")
```