### PR TITLE
Add automated monthly maintenance builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,14 +77,13 @@ jobs:
 
 workflows:
   version: 2
-  build:
+
+  commit:
     jobs:
       - build
-
       - test:
           requires:
             - build
-
       - deploy:
           requires:
             - test
@@ -92,3 +91,20 @@ workflows:
             branches:
               only:
                 - master
+
+  monthly:
+    triggers:
+      - schedule:
+          cron: "0 0 1 * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - deploy:
+          requires:
+            - test


### PR DESCRIPTION
This will allow for picking up any base image updates (Alpine and/or Node.js) for security purposes even if there are no new commits in the tiddlywiki-docker repository. Most of the official distros only push new tags about once a month, and I don't want to be continually pestered if there's a breaking change, so a monthly schedule seemed reasonable.

For people that need consistency for deployments, there are always the static unique tags.