### PR TITLE
Always make a unique tag, locally or in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_HUB_REPOSITORY ?= elasticdog
 all: build
 
 .PHONY: build
-build: SOURCE_COMMIT := $(shell git rev-parse HEAD)
+build: SOURCE_COMMIT = $(shell git rev-parse HEAD)
 build:
 	docker build --build-arg "SOURCE_COMMIT=${SOURCE_COMMIT}" --tag tiddlywiki .
 
@@ -13,12 +13,13 @@ test:
 	cd tests/ && dgoss run tiddlywiki --server
 
 .PHONY: tag
-tag: PATCH_VERSION := $(shell docker run -it --rm tiddlywiki --version | sed 's/[^0-9.]*//g')
-tag: MINOR_VERSION := $(shell echo "${PATCH_VERSION}" | awk -F. '{ print $$1"."$$2 }')
-tag: MAJOR_VERSION := $(shell echo "${PATCH_VERSION}" | awk -F. '{ print $$1 }')
+tag: UNIQUE_TAG = $(shell printf '%s.%s' "$$(date +%Y%m%d)" "$${CIRCLE_BUILD_NUM:-$$(git rev-parse --short=12 HEAD)}")
+tag: PATCH_VERSION = $(shell docker run -it --rm tiddlywiki --version | sed 's/[^0-9.]*//g')
+tag: MINOR_VERSION = $(shell echo "${PATCH_VERSION}" | awk -F. '{ print $$1"."$$2 }')
+tag: MAJOR_VERSION = $(shell echo "${PATCH_VERSION}" | awk -F. '{ print $$1 }')
 tag:
 	# unique tag
-	if [ "$$CI" = true ]; then docker tag tiddlywiki "${DOCKER_HUB_REPOSITORY}/tiddlywiki:$$(date +%Y%m%d).$${CIRCLE_BUILD_NUM}"; fi
+	docker tag tiddlywiki "${DOCKER_HUB_REPOSITORY}/tiddlywiki:${UNIQUE_TAG}"
 	# stable tags
 	docker tag tiddlywiki "${DOCKER_HUB_REPOSITORY}/tiddlywiki:latest"
 	docker tag tiddlywiki "${DOCKER_HUB_REPOSITORY}/tiddlywiki:${PATCH_VERSION}"


### PR DESCRIPTION
The reason for supporting a local unique tag would be if a manual build happens for some reason and needs to get pushed. That said, when running locally, we use the short Git commit SHA instead of the build number, since that's not applicable. It's a sane fallback, but one that shouldn't come up very often.