### PR TITLE
Exclude a few more files in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
-tests/*
+.circleci/*
+.git/*
 contrib/*
-Makefile
+tests/*
+.editorconfig
 LICENSE
-*.txt
+Makefile
 *.md
+*.txt


### PR DESCRIPTION
I do wish I could have figured out the "ignore everything except for any _Dockerfile_ rule", but this works for now.