### PR TITLE
Revert to the default loading strategy when serving

### DIFF
--- a/contrib/tiddlywiki-serve
+++ b/contrib/tiddlywiki-serve
@@ -70,7 +70,7 @@ docker run --detach --rm \
 	--mount "type=bind,source=${PWD},target=/tiddlywiki" \
 	--user "$(id -u):$(id -g)" \
 	"elasticdog/tiddlywiki:${TIDDLYWIKI_DOCKER_TAG}" \
-	--server 8080 '$:/core/save/lazy-all' text/plain text/html '' '' 0.0.0.0 > /dev/null
+	--server 8080 '$:/core/save/all' text/plain text/html '' '' 0.0.0.0 > /dev/null
 
 exit_status=$?
 if [[ $exit_status -ne 0 ]]; then


### PR DESCRIPTION
The lazy loading causes unexpected behavior when renaming tiddlers. The previous version of the tiddler remains on disk and ends up in various dynamic link lists. I also experienced some issues with Draft tiddlers that hung around.