### PR TITLE
Support the latest upstream TiddlyWiki release v5.1.18

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-ENV TIDDLYWIKI_VERSION=5.1.17
+ENV TIDDLYWIKI_VERSION=5.1.18
 
 ARG SOURCE_COMMIT
 LABEL maintainer="Aaron Bull Schaefer <aaron@elasticdog.com>"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 
 .PHONY: test
 test:
-	cd tests/ && dgoss run tiddlywiki --server
+	cd tests/ && dgoss run tiddlywiki --listen
 
 .PHONY: tag
 tag: UNIQUE_TAG = $(shell printf '%s.%s' "$$(date +%Y%m%d)" "$${CIRCLE_BUILD_NUM:-$$(git rev-parse --short=12 HEAD)}")

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Assuming the interactive wrapper script is named `tiddlywiki-docker` and exists 
 
 2. Start the TiddlyWiki server:
    ```
-   $ ./tiddlywiki-docker mynewwiki --server 8080 '$:/core/save/all' text/plain text/html '' '' 0.0.0.0
+   $ ./tiddlywiki-docker mynewwiki --listen host=0.0.0.0
    Serving on 0.0.0.0:8080
    (press ctrl-C to exit)
     syncer-server-filesystem: Dispatching 'save' task: $:/StoryList
@@ -96,7 +96,7 @@ docker run --detach --rm \
 	--user "$(id -u):$(id -g)" \
 	elasticdog/tiddlywiki \
 	"$WIKIFOLDER" \
-	--server 8080 '$:/core/save/all' text/plain text/html '' '' 0.0.0.0
+	--listen host=0.0.0.0
 ```
 
 #### Background Example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`5.1.17`, `5.1`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.1.18`, `5.1`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.1.17` (*5/Dockerfile* @ fdac15a)](https://github.com/elasticdog/tiddlywiki-docker/blob/fdac15a3a930365c98e3474492465e77e0148c55/5/Dockerfile)
 
 ## TiddlyWiki Docker
 

--- a/contrib/tiddlywiki-serve
+++ b/contrib/tiddlywiki-serve
@@ -70,7 +70,7 @@ docker run --detach --rm \
 	--mount "type=bind,source=${PWD},target=/tiddlywiki" \
 	--user "$(id -u):$(id -g)" \
 	"elasticdog/tiddlywiki:${TIDDLYWIKI_DOCKER_TAG}" \
-	--server 8080 '$:/core/save/all' text/plain text/html '' '' 0.0.0.0 > /dev/null
+	--listen host=0.0.0.0 > /dev/null
 
 exit_status=$?
 if [[ $exit_status -ne 0 ]]; then


### PR DESCRIPTION
Bump version to the [latest upstream release](https://tiddlywiki.com/#Release%205.1.18) and remove usage of deprecated `--server` command in favor of the new `--listen` command that supports named parameters 🎉 .