### PR TITLE
Bump version to the latest upstream release 5.1.19

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-ENV TIDDLYWIKI_VERSION=5.1.18
+ENV TIDDLYWIKI_VERSION=5.1.19
 
 ARG SOURCE_COMMIT
 LABEL maintainer="Aaron Bull Schaefer <aaron@elasticdog.com>"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018, Aaron Bull Schaefer <aaron@elasticdog.com>
+Copyright (c) 2018-2019, Aaron Bull Schaefer <aaron@elasticdog.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`5.1.18`, `5.1`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.1.19`, `5.1`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.1.18` (*5/Dockerfile* @ 2ead91d)](https://github.com/elasticdog/tiddlywiki-docker/blob/2ead91df276b99724e795c96cdd59e26c367d8d9/5/Dockerfile)
 - [`5.1.17` (*5/Dockerfile* @ fdac15a)](https://github.com/elasticdog/tiddlywiki-docker/blob/fdac15a3a930365c98e3474492465e77e0148c55/5/Dockerfile)
 
 ## TiddlyWiki Docker

--- a/README.md
+++ b/README.md
@@ -134,6 +134,6 @@ The TiddlyWiki Docker project welcomes contributions from everyone. If you're th
 
 tiddlywiki-docker is provided under the terms of the [MIT License][].
 
-Copyright &copy; 2018, [Aaron Bull Schaefer](mailto:aaron@elasticdog.com).
+Copyright &copy; 2018&ndash;2019, [Aaron Bull Schaefer](mailto:aaron@elasticdog.com).
 
 [MIT License]: https://en.wikipedia.org/wiki/MIT_License


### PR DESCRIPTION
See: https://tiddlywiki.com/#Release%205.1.19