### PR TITLE
Bump version to the latest upstream release 5.1.20

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-ENV TIDDLYWIKI_VERSION=5.1.19
+ENV TIDDLYWIKI_VERSION=5.1.20
 
 ARG SOURCE_COMMIT
 LABEL maintainer="Aaron Bull Schaefer <aaron@elasticdog.com>"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`5.1.19`, `5.1`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.1.20`, `5.1`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.1.19` (*5/Dockerfile* @ ae02af4)](https://github.com/elasticdog/tiddlywiki-docker/blob/ae02af419ead75508c7e1abcf75d00d79c0192b8/5/Dockerfile)
 - [`5.1.18` (*5/Dockerfile* @ 2ead91d)](https://github.com/elasticdog/tiddlywiki-docker/blob/2ead91df276b99724e795c96cdd59e26c367d8d9/5/Dockerfile)
 - [`5.1.17` (*5/Dockerfile* @ fdac15a)](https://github.com/elasticdog/tiddlywiki-docker/blob/fdac15a3a930365c98e3474492465e77e0148c55/5/Dockerfile)
 


### PR DESCRIPTION
See: https://tiddlywiki.com/#Release%205.1.20

`make build` and `make test` passed locally.