### PR TITLE
Update to 5.2.x

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-ENV TIDDLYWIKI_VERSION=5.2.2
+ENV TIDDLYWIKI_VERSION=5.2.3
 
 ARG SOURCE_COMMIT
 LABEL maintainer="Aaron Bull Schaefer <aaron@elasticdog.com>"

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-ENV TIDDLYWIKI_VERSION=5.1.23
+ENV TIDDLYWIKI_VERSION=5.2.0
 
 ARG SOURCE_COMMIT
 LABEL maintainer="Aaron Bull Schaefer <aaron@elasticdog.com>"

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-ENV TIDDLYWIKI_VERSION=5.2.1
+ENV TIDDLYWIKI_VERSION=5.2.2
 
 ARG SOURCE_COMMIT
 LABEL maintainer="Aaron Bull Schaefer <aaron@elasticdog.com>"

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 
-ENV TIDDLYWIKI_VERSION=5.2.0
+ENV TIDDLYWIKI_VERSION=5.2.1
 
 ARG SOURCE_COMMIT
 LABEL maintainer="Aaron Bull Schaefer <aaron@elasticdog.com>"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2021, Aaron Bull Schaefer <aaron@elasticdog.com>
+Copyright (c) 2018-2022, Aaron Bull Schaefer <aaron@elasticdog.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`5.2.1`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
-- [`5.2.0`, (*5/Dockerfile @ 5797dec*)](https://github.com/elasticdog/tiddlywiki-docker/blob/5797dec96dcdae75b60925ca9422eece800223ce/5/Dockerfile)
-- [`5.1.23` `5.1` (*5/Dockerfile* @e5bd122)](https://github.com/elasticdog/tiddlywiki-docker/blob/e5bd1226fbc21b7747ebd7bad22a8c7673ab8b0c/5/Dockerfile)
-- [`5.1.22` (*5/Dockerfile* @ 3e4df0f)](https://github.com/elasticdog/tiddlywiki-docker/blob/3e4df0f8a33db4fac6724ada969705c1622a5af0/5/Dockerfile)
-- [`5.1.21` (*5/Dockerfile* @ 5368ab2)](https://github.com/elasticdog/tiddlywiki-docker/blob/5368ab2480dd98dfdbd611e6344e2d6e3c389369/5/Dockerfile)
-- [`5.1.19` (*5/Dockerfile* @ a29642c)](https://github.com/elasticdog/tiddlywiki-docker/blob/a29642cab96186390b6866e45f56cd74807c39ba/5/Dockerfile)
-- [`5.1.18` (*5/Dockerfile* @ 2ead91d)](https://github.com/elasticdog/tiddlywiki-docker/blob/2ead91df276b99724e795c96cdd59e26c367d8d9/5/Dockerfile)
-- [`5.1.17` (*5/Dockerfile* @ fdac15a)](https://github.com/elasticdog/tiddlywiki-docker/blob/fdac15a3a930365c98e3474492465e77e0148c55/5/Dockerfile)
+- [`5.2.2`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.2.1`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.2.1/5/Dockerfile)
+- [`5.2.0`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.2.0/5/Dockerfile)
+- [`5.1.23` `5.1`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.1.23/5/Dockerfile)
+- [`5.1.22`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.1.22/5/Dockerfile)
+- [`5.1.21`https://github.com/elasticdog/tiddlywiki-docker/blob/5.1.21/5/Dockerfile)
+- [`5.1.19`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.1.19/5/Dockerfile)
+- [`5.1.18`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.1.18/5/Dockerfile)
+- [`5.1.17`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.1.17/5/Dockerfile)
 
 ## TiddlyWiki Docker
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - [`5.2.1`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
 - [`5.2.0`, (*5/Dockerfile @ 5797dec*)](https://github.com/elasticdog/tiddlywiki-docker/blob/5797dec96dcdae75b60925ca9422eece800223ce/5/Dockerfile)
-- [`5.1.23` `5.1` (*5/Dockerfile* @ 3e4df0f)](https://github.com/elasticdog/tiddlywiki-docker/blob/e5bd1226fbc21b7747ebd7bad22a8c7673ab8b0c/5/Dockerfile)
+- [`5.1.23` `5.1` (*5/Dockerfile* @e5bd122)](https://github.com/elasticdog/tiddlywiki-docker/blob/e5bd1226fbc21b7747ebd7bad22a8c7673ab8b0c/5/Dockerfile)
 - [`5.1.22` (*5/Dockerfile* @ 3e4df0f)](https://github.com/elasticdog/tiddlywiki-docker/blob/3e4df0f8a33db4fac6724ada969705c1622a5af0/5/Dockerfile)
 - [`5.1.21` (*5/Dockerfile* @ 5368ab2)](https://github.com/elasticdog/tiddlywiki-docker/blob/5368ab2480dd98dfdbd611e6344e2d6e3c389369/5/Dockerfile)
 - [`5.1.19` (*5/Dockerfile* @ a29642c)](https://github.com/elasticdog/tiddlywiki-docker/blob/a29642cab96186390b6866e45f56cd74807c39ba/5/Dockerfile)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`5.1.23`, `5.1`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.2.0`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.1.23` `5.1` (*5/Dockerfile* @ 3e4df0f)](https://github.com/elasticdog/tiddlywiki-docker/blob/e5bd1226fbc21b7747ebd7bad22a8c7673ab8b0c/5/Dockerfile)
 - [`5.1.22` (*5/Dockerfile* @ 3e4df0f)](https://github.com/elasticdog/tiddlywiki-docker/blob/3e4df0f8a33db4fac6724ada969705c1622a5af0/5/Dockerfile)
 - [`5.1.21` (*5/Dockerfile* @ 5368ab2)](https://github.com/elasticdog/tiddlywiki-docker/blob/5368ab2480dd98dfdbd611e6344e2d6e3c389369/5/Dockerfile)
 - [`5.1.19` (*5/Dockerfile* @ a29642c)](https://github.com/elasticdog/tiddlywiki-docker/blob/a29642cab96186390b6866e45f56cd74807c39ba/5/Dockerfile)
@@ -28,13 +29,13 @@ These Docker images are meant to replicate the functionality of the `tiddlywiki`
 
 That said, there are a few caveats to consider when using a Docker-ized version of this command:
 
-- **Port Publishing**  
+- **Port Publishing**
   The _Dockerfile_ exposes port 8080 from the container, but you must bind to `0.0.0.0` rather than the default `127.0.0.1` (localhost) when running the HTTP server interface, or connectivity won't work from the host.
 
-- **Data Persistence**  
+- **Data Persistence**
   If you actually want to persist your tiddlers, you'll need to [get them out of the container][]; you can use either volumes or bind mounts. In the container, there is a predefined data volume under `/tiddlywiki` that is used as the default working directory.
 
-- **Ownership Permissions**  
+- **Ownership Permissions**
   If you do use a _bind mount_, don't forget that the process running within the **container** will change the **host** filesystem. You should run the container with the `--user` option so that files are created with the desired ownership.
 
 To facilitate handling these things, you can write short wrapper scripts for common scenarios...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`5.2.2`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.2.3`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.2.1`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.2.2/5/Dockerfile)
 - [`5.2.1`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.2.1/5/Dockerfile)
 - [`5.2.0`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.2.0/5/Dockerfile)
 - [`5.1.23` `5.1`](https://github.com/elasticdog/tiddlywiki-docker/blob/5.1.23/5/Dockerfile)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Supported tags and respective `Dockerfile` links
 
-- [`5.2.0`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.2.1`, `5.2`, `5`, `latest` (*5/Dockerfile*)](https://github.com/elasticdog/tiddlywiki-docker/blob/master/5/Dockerfile)
+- [`5.2.0`, (*5/Dockerfile @ 5797dec*)](https://github.com/elasticdog/tiddlywiki-docker/blob/5797dec96dcdae75b60925ca9422eece800223ce/5/Dockerfile)
 - [`5.1.23` `5.1` (*5/Dockerfile* @ 3e4df0f)](https://github.com/elasticdog/tiddlywiki-docker/blob/e5bd1226fbc21b7747ebd7bad22a8c7673ab8b0c/5/Dockerfile)
 - [`5.1.22` (*5/Dockerfile* @ 3e4df0f)](https://github.com/elasticdog/tiddlywiki-docker/blob/3e4df0f8a33db4fac6724ada969705c1622a5af0/5/Dockerfile)
 - [`5.1.21` (*5/Dockerfile* @ 5368ab2)](https://github.com/elasticdog/tiddlywiki-docker/blob/5368ab2480dd98dfdbd611e6344e2d6e3c389369/5/Dockerfile)


### PR DESCRIPTION
Supersedes #32 
Fixes #30 
Uses git tags per #33

This PR adds v5.2.0, v5.2.1, and v5.2.2.
Updates copyright year.

The README.md references old Dockerfiles via git tags rather than commit IDs.